### PR TITLE
Smarter metric collection and reporting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ netdata_python_d_conf_template: python.d.conf.j2
 netdata_python_d_conf_path: /etc/netdata/python.d.conf
 netdata_apps_groups_conf_template: apps_groups.conf.j2
 netdata_apps_groups_conf_path: /etc/netdata/apps_groups.conf
+netdata_apps_groups_monitor_all: false
 
 # netdata.conf
 netdata_run_as_user: netdata
@@ -31,6 +32,49 @@ netdata_backend_hostname: "{{ ansible_hostname }}"
 netdata_backend_update_every: 10
 netdata_backend_buffer_on_failures: 60
 netdata_backend_timeout_ms: 20000
+netdata_backend_charts:
+    - "*apps*"
+    - "*disk_backlog*"
+    - "*disk_util*"
+    - "*disk_inodes*"
+    - "*disk_ops*"
+    - "*disk_space*"
+    - "*ipv4.errors*"
+    - "*ipv4.tcpsock*"
+    - "*ipv4.tcppackets*"
+    - "*ipv4.tcperrors*"
+    - "*ipv4.packets*"
+    - "*ipv4.tcphandshake*"
+    - "*ipv4.udppackets*"
+    - "*mem.committed*"
+    - "*net_drops*"
+    - "*net_packets*"
+    - "*net.*"
+    - "*system.ctxt*"
+    - "*system.cpu*"
+    - "*system.ram*"
+    - "*system.io*"
+    - "*system.processes*"
+    - "*system.load*"
+    - "*system.uptime*"
+    - "*system.forks*"
+    - "*response_time*"
+    - "*requests*"
+    - "*plugin_pythond_web_log*"
+    - "*web_log_.openio*"
+
+netdata_active_plugins:
+    apps: yes
+    cgroups: no
+    charts.d: no
+    checks: no
+    diskspace: yes
+    fping: no
+    idlejitter: no
+    node.d: no
+    proc: yes
+    python.d: yes
+    tc: no
 
 # plugin.d.conf
 # Quote yes/no values

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,7 +3,6 @@
   apt_repository:
     repo: "deb {{ openio_sds_repository }}/{{ ansible_distribution }}/ {{ ansible_distribution_release }}/"
     state: present
-    filename: 'openio-sds'
 
 - name: "Debian| add OpenIO repo key"
   apt_key:

--- a/templates/apps_groups.conf.j2
+++ b/templates/apps_groups.conf.j2
@@ -18,6 +18,7 @@ openio.redis: *redis-*
 openio.redissentinel: *redissentinel-*
 openio.zookeeper: *zookeeper-*
 
+{% if netdata_apps_groups_monitor_all %}
 # -----------------------------------------------------------------------------
 # NETDATA processes accounting
 
@@ -198,3 +199,5 @@ crsproxy: crsproxy
 sidekiq: *sidekiq*
 java: java
 ipfs: ipfs
+
+{% endif %}

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -8,8 +8,8 @@
   {% if netdata_bind_socket_to_IP -%}
   bind socket to IP = {{ netdata_bind_socket_to_IP }}
   {%- endif -%}
-{% if netdata_backend_enabled %}
 
+{% if netdata_backend_enabled %}
 [backend]
   enabled = yes
   type = {{ netdata_backend_type }}
@@ -20,4 +20,21 @@
   update every = {{ netdata_backend_update_every }}
   buffer on failures = {{ netdata_backend_buffer_on_failures }}
   timeout ms = {{ netdata_backend_timeout_ms }}
+  send charts matching = {{ netdata_backend_charts | join(' ')}}
 {% endif %}
+
+[plugins]
+{% for plugin, state in netdata_active_plugins.iteritems() -%}
+  {{plugin}} = {{active}}
+{% endfor -%}
+
+[netdata.backend_metrics]
+  enabled=no
+[netdata.backend_bytes]
+  enabled=no
+[netdata.backend_ops]
+  enabled=no
+[netdata.backend_thread_cpu]
+  enabled=no
+[netdata.private_charts]
+  enabled=no

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -7,7 +7,7 @@
   # networks.See https://github.com/firehol/netdata/issues/164
   {% if netdata_bind_socket_to_IP -%}
   bind socket to IP = {{ netdata_bind_socket_to_IP }}
-  {%- endif -%}
+  {% endif %}
 
 {% if netdata_backend_enabled %}
 [backend]
@@ -24,17 +24,21 @@
 {% endif %}
 
 [plugins]
-{% for plugin, state in netdata_active_plugins.iteritems() -%}
-  {{plugin}} = {{active}}
-{% endfor -%}
+{% for plugin, state in netdata_active_plugins.iteritems() %}
+  {{plugin}} = {{ 'yes' if state else 'no' }}
+{% endfor %}
 
 [netdata.backend_metrics]
   enabled=no
+
 [netdata.backend_bytes]
   enabled=no
+
 [netdata.backend_ops]
   enabled=no
+
 [netdata.backend_thread_cpu]
   enabled=no
+
 [netdata.private_charts]
   enabled=no


### PR DESCRIPTION
By default netdata send a lot of metrics to the backend, many of which aren't actually used by other components in the stack. This adds options + proper defaults to disable collection of those metrics, aswell as filter metrics that are being sent to the backend.