### PR TITLE
Remove the openio_netdata_apps_groups_monitor_all part

### DIFF
--- a/templates/apps_groups.conf.j2
+++ b/templates/apps_groups.conf.j2
@@ -18,22 +18,3 @@ openio.rdir: oio-rdir-server
 openio.redis: *redis-*
 openio.redissentinel: *redissentinel-*
 openio.zookeeper: *zookeeper-*
-
-{% if openio_netdata_apps_groups_monitor_all %}
-# -----------------------------------------------------------------------------
-# NETDATA processes accounting
-
-# netdata main process
-netdata: netdata
-
-# netdata known plugins
-# plugins not defined here will be accumulated in netdata, above
-apps.plugin: apps.plugin
-freeipmi.plugin: freeipmi.plugin
-charts.d.plugin: *charts.d.plugin*
-node.d.plugin: *node.d.plugin*
-python.d.plugin: *python.d.plugin*
-tc-qos-helper: *tc-qos-helper.sh*
-fping: fping
-
-{% endif %}


### PR DESCRIPTION
This part is obsolete, the `vars/main.yml` doesn't defined it any more.