### PR TITLE
FEATURE(netdata): Control netdata startup at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ An Ansible role for install netdata. Specifically, the responsibilities of this 
 | openio_netdata_inventory_oio_group         | Group name of monitored nodes that run OpenIO (should be a subgroup of netdata group) | string  |
 | openio_netdata_oiofs_monitor               | Activate oiofs monitoring (Use as hostvar)                                            | boolean |
 | openio_netdata_oiofs_endpoints             | oiofs endpoints to monitor (Use as hostvar)                                           | dict    |
+| openio_netdata_service_enabled             | Enable service at system boot                                                         | boolean |
 
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@ openio_netdata_bind_address:
 openio_netdata_bind_port: 19999
 openio_netdata_global_update_every: 10
 
+openio_netdata_service_enabled: true
+
 openio_netdata_backend_hostname: "{{ ansible_hostname }}"
 openio_netdata_backend_timeout_ms: 20000
 openio_netdata_backend_enabled: 'no'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,5 +109,5 @@
   service:
     name: netdata
     state: "{{ 'restarted' if openio_netdata_provision_only else 'started' }}"
-    enabled: true
+    enabled: "{{ openio_netdata_service_enabled }}"
 ...


### PR DESCRIPTION
 ##### SUMMARY
Allow to control if netdata should be running or not
when system boot up.
By default, netdata is running.

 ##### IMPACT
N/A