### PR TITLE
BUGFIX/MEDIUM(netdata): Fix oio_hosts default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for ansible-role-openio-netdata
 openio_netdata_namespace: "{{ namespace | d(default_namespace) }}"
 openio_netdata_confdir: "/etc/netdata"
-openio_netdata_oio_hosts: "{{ groups['fronts'] | d([]) + groups['backs'] | d[] + openio_netdata_oiofs_hosts }}"
+openio_netdata_oio_hosts: "{{ groups['fronts'] | d([]) + groups['backs'] | d([]) + openio_netdata_oiofs_hosts }}"
 openio_netdata_oiofs_hosts: "{{ groups['oiofs'] | d([]) + groups['oiofs_ha'] | d([]) }}"
 openio_netdata_s3rt_hosts: "{{ [(groups['fronts'] | first), (groups['fronts'] | last)]
   if (groups['fronts'] | d([])) | length > 1 else [] }}"

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -13,11 +13,15 @@
       copy:
         src: inventory.yml
         dest: "/etc/oio/sds/{{ namespace }}/inventory.yml"
+    - name: Add localhost to group 'fronts'
+      add_host:
+        name: localhost
+        groups: fronts
+      changed_when: false
   roles:
     - role: users
     - role: repo
       openio_repository_no_log: false
       openio_repository_mirror_host: mirror2.openio.io
     - role: role_under_test
-      openio_netdata_oio_hosts: [ 'localhost' ]
 ...


### PR DESCRIPTION
 ##### SUMMARY

openio_netdata_oio_hosts default was broken and undetectable by CI. This
fixes the default and makes sure it is tested

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION