### PR TITLE
BUGFIX/MINOR(netdata): Fix plugins VIP and NS arguments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,7 +29,7 @@ openio_netdata_oiofs_mountpoints: "{{ oiofs_mountpoints | d([]) }}"
 openio_netdata_python_d_retry: 300
 openio_netdata_provision_only: false
 
-openio_netdata_s3rt_endpoint: "http://{{ vip | d('localhost')}}:6007"
+openio_netdata_s3rt_endpoint: "http://{{ openio_bind_virtual_address | d('localhost')}}:6007"
 openio_netdata_s3rt_region: "{{ openio_s3_region | d(default_openio_s3_region) }}"
 openio_netdata_s3rt_bucket: "s3roundtrip-bucket"
 openio_netdata_s3rt_object: "s3roundtrip-object"

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -45,7 +45,7 @@
 
 [plugin:command]
   update_every = {{ openio_netdata_global_update_every }}
-  command options = --ns {{ openio_netdata_namespace }}
+  command options = --conf {{ openio_netdata_confdir }}/commands.conf
 
 [plugin:zookeeper]
   update_every = {{ openio_netdata_global_update_every }}


### PR DESCRIPTION
 ##### SUMMARY

Netdata plugins had 2 invocation issues: command collector was invoked
with invalid --ns argument, S3 roundtrip was using the wrong VIP
variable. This fixes both these cases

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION