### PR TITLE
BUGFIX/MEDIUM(netdata): Ensure roundtrip info is scraped

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -62,6 +62,7 @@ openio_netdata_backend_charts:
   - "*version*"
   - "*zk*"
   - "*oiofs*"
+  - "roundtrip*"
 
 openio_netdata_active_plugins:
   apps: true


### PR DESCRIPTION
 ##### SUMMARY

S3 Roundrip information wasn't declared in the whitelist so it wasn't
properly collected. This ensures it is exposed to prometheus.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION