### PR TITLE
BUGFIX/MEDIUM(netdata): Fix privilege escalation when creating tempdir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,16 +46,7 @@
         suffix: inventory
       register: inv_dir
       changed_when: false
-      tags: configure
-
-    - name: Make temporary directory writeable
-      local_action:
-        module: file
-        path: "{{ inv_dir.path }}"
-        owner: root
-        group: root
-        mode: '0777'
-      changed_when: false
+      become: false
       tags: configure
 
     - name: "Fetch inventory file"


### PR DESCRIPTION
 ##### SUMMARY

Using become=true for local actions is dangerous as the controller it
not guaranteed to have a proper privilege escalation mechanism (e.g.
sudo not installed). This fixes the tempdir creation for the inventory
to not use become.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION