### PR TITLE
BUGFIX/MINOR(netdata): Fix output of keystone and beanstalkd versions

### DIFF
--- a/files/commands/Debian.conf
+++ b/files/commands/Debian.conf
@@ -5,6 +5,6 @@ s3_version=dpkg-query -Wf='${Version}\n' openio-sds-swift-plugin-s3
 redis_version=redis-server --version | grep -oP ' v=\K.+? '
 zk_version=dpkg-query -Wf='${Version}\n' zookeeper
 zk_lib_version=dpkg-query -Wf='${Version}\n' libzookeeper-java
-beanstalkd_version=beanstalkd -v | awk '{print $2}'
+beanstalkd_version=beanstalkd -v | awk 'BEGIN {err=1} NF == 2 {print $2; err = 0} END {exit err}'
 oiofs_version=dpkg-query -Wf='${Version}\n' oiofs-fuse
-keystone_version=keystone-manage --version
+keystone_version=keystone-manage --version 2>&1

--- a/files/commands/RedHat.conf
+++ b/files/commands/RedHat.conf
@@ -5,6 +5,6 @@ s3_version=rpm -q --qf "%{VERSION}\n" openio-sds-swift-plugin-swift3
 redis_version=redis-server --version | grep -oP ' v=\K.+? '
 zk_version=rpm -q --qf "%{VERSION}\n" zookeeper
 zk_lib_version=rpm -q --qf "%{VERSION}\n" zookeeper-lib
-beanstalkd_version=beanstalkd -v | awk '{print $2}'
+beanstalkd_version=beanstalkd -v | awk 'BEGIN {err=1} NF == 2 {print $2; err = 0} END {exit err}'
 oiofs_version=rpm -q --qf "%{VERSION}\n" oiofs-fuse
-keystone_version=keystone-manage --version
+keystone_version=keystone-manage --version 2>&1


### PR DESCRIPTION
 ##### SUMMARY

Previously, when beanstalkd binary was absent, the collection command
would exit with 0 because awk is permissive. Also keystone-manage was
outputting the version to stderr meaning the version wasn't captured.
This fixes both of these issues

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION