### PR TITLE
CHANGE(netdata): use netdata host tags

### DIFF
--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -20,6 +20,7 @@
 {% if openio_netdata_backend_destination %}
   destination = {{ openio_netdata_backend_destination }}
 {% endif %}
+  host tags = ansible_name="{{ inventory_hostname }}" namespace="{{ openio_netdata_namespace }}"
 
 
 [plugins]


### PR DESCRIPTION
 ##### SUMMARY
Add the ansible inventory hostname and the namespace in the host tags.
The change is required by the UI to match ansible inventory hostnames and real hostnames.

 ##### IMPACT
N/A