### PR TITLE
BUGFIX/MEDIUM(netdata): Fix recursive loop on admin node

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
 
 - name: Set global configuration
   vars:
-    inventory: "{{ inventory | d({}) }}"
+    _inventory: "{{ inventory | d({}) }}"
   template:
     src: netdata.conf.j2
     dest: /etc/netdata/netdata.conf

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -20,7 +20,7 @@
 {% if openio_netdata_backend_destination %}
   destination = {{ openio_netdata_backend_destination }}
 {% endif %}
-  host tags = ansible_name="{{ inventory_hostname }}" namespace="{{ openio_netdata_namespace }}" rack="{{ inventory.get('rack', '') }}"
+  host tags = ansible_name="{{ inventory_hostname }}" namespace="{{ openio_netdata_namespace }}" rack="{{ _inventory.get('rack', '') }}"
 
 
 [plugins]


### PR DESCRIPTION
 ##### SUMMARY

Currently, the admin node can't be installed

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Error was:
```console
atal: [N100]: FAILED! =>
  msg: 'An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>,
    original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was
    a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating
    ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled
    exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>,
    original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was
    a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating
    ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled
    exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>,
    original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was
    a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating
    ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled
    exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>,
    original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was
    a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating
    ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: An unhandled exception occurred while templating ''{{ inventory | d({}) }}''. Error was a <class ''ansible.errors.AnsibleError''>, original message: recursive loop detected in template string: {{ inventory | d({}) }}'
```