### PR TITLE
FEATURE(netdata): Allow monitoring of multi redis clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ An Ansible role for install netdata. Specifically, the responsibilities of this 
 | openio_netdata_oiofs_monitor               | Activate oiofs monitoring (Use as hostvar)                                            | boolean |
 | openio_netdata_oiofs_endpoints             | oiofs endpoints to monitor (Use as hostvar)                                           | dict    |
 | openio_netdata_service_enabled             | Enable service at system boot                                                         | boolean |
+| openio_netdata_redis_account_group             | Ansible group of hosts for the account redis backend boot                                                         | string |
 
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,8 @@ openio_netdata_oiofs_hosts: "{{ groups['oiofs'] | d([]) + groups['oiofs_ha'] | d
 openio_netdata_s3rt_hosts: "{{ [(groups['oioswift'] | first), (groups['oioswift'] | last)]
   if (groups['oioswift'] | d([])) | length > 1 else [] }}"
 openio_netdata_zookeeper_hosts: "{{ groups['zookeeper'] | d([]) }}"
-openio_netdata_redis_hosts: "{{ groups['redis'] | d([]) }}"
+openio_netdata_redis_account_group: "redis"
+openio_netdata_redis_hosts: "{{ groups[openio_netdata_redis_account_group] | d([]) }}"
 
 openio_netdata_bind_interface: "{{ openio_bind_mgmt_interface | d(ansible_default_ipv4.alias) }}"
 openio_netdata_bind_address: "{{ openio_bind_mgmt_address \

--- a/docker-tests/inventory.yml
+++ b/docker-tests/inventory.yml
@@ -345,6 +345,7 @@ namespaces:
           location: ''
           partition: ''
           port: 6011
+          role: "redis"
           volume: /mnt/ssd/TRAVIS/redis-0
       redissentinel:
         - config: {}

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -40,9 +40,12 @@
   update_every = {{ openio_netdata_global_update_every }}
   command options = --ns {{ openio_netdata_namespace }}
 
+{% set targets = inventory.services.get('redis', []) | selectattr('role', 'match', openio_netdata_redis_account_group) | list %}
+{% if targets %}
 [plugin:container]
   update_every = {{ openio_netdata_global_update_every }}
-  command options = --ns {{ openio_netdata_namespace }} --fast
+  command options = --ns {{ openio_netdata_namespace }} --fast --addr {{ targets[0].ip }}:{{ targets[0].port }}
+{% endif %}
 
 [plugin:command]
   update_every = {{ openio_netdata_global_update_every }}


### PR DESCRIPTION
 ##### SUMMARY

This allows for compatibility with multiple redis clusters

To use, simply configure the proper value of the `openio_netdata_redis_account_group`
to target the ansible group of the redis hosts for the account backend.

Example:

`openio_netdata_redis_account_group: "redis-account"`

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

Requirements:
- openio-netdata-plugins 0.5.1+
- https://github.com/open-io/customer-skeleton/pull/207