### PR TITLE
BUGFIX/MEDIUM(netdata): Fix privilege escalation when creating tempdir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
         state: directory
         suffix: inventory
       register: inv_dir
+      become: false
       changed_when: false
 
     - name: Make temporary directory writeable


### PR DESCRIPTION
 ##### SUMMARY

Using become=true for local actions is dangerous as the controller it
not guaranteed to have a proper privilege escalation mechanism (e.g.
sudo not installed). This fixes the tempdir creation for the inventory
to not use become.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION