### PR TITLE
BUGFIX/MINOR(netdata): Fix python2 retro-compat, test S3 roundtrip

### DIFF
--- a/docker-tests/test_all.yml
+++ b/docker-tests/test_all.yml
@@ -5,6 +5,8 @@
   become: true
   vars:
     namespace: TRAVIS
+    openio_netdata_s3rt_hosts: [ "localhost" ]
+    default_openio_s3_region: "us-east-1"
   pre_tasks:
     - name: Seed directory for NS
       file:
@@ -24,6 +26,14 @@
         name: localhost
         groups: fronts
       changed_when: false
+    - name: "Create .aws directory"
+      file:
+        state: directory
+        dest: "/root/.aws"
+    - name: "Seed .aws/credentials file"
+      copy:
+        content: "[default]\naws_access_key_id=test_access\naws_secret_access_key=test_secret\n"
+        dest: "/root/.aws/credentials"
   roles:
     - role: users
     - role: repo

--- a/filter_plugins/netdata.py
+++ b/filter_plugins/netdata.py
@@ -1,8 +1,11 @@
 from base64 import b64decode
 try:
+    # Python 3
     import configparser
 except ImportError:
+    # Python 2
     import ConfigParser as configparser
+    import io
 
 
 class FilterModule(object):
@@ -15,7 +18,10 @@ class FilterModule(object):
         """ Retrieves AWS creds from b64 encoded data received by slurp """
         config = configparser.ConfigParser()
         config.optionxform = str
-        config.read_string(b64decode(data).decode('utf-8'))
+        try:
+            config.read_string(b64decode(data).decode('utf-8'))
+        except AttributeError:
+            config.readfp(io.BytesIO(b64decode(data)))
         if type_ == 'secret':
             return config.get('default', 'aws_secret_access_key')
         return config.get('default', 'aws_access_key_id')


### PR DESCRIPTION
 ##### SUMMARY

This ensures the aws/credentials filter is working with python2 and
enforces the S3 roundtrip plugin to be deployed during the CI tests

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION