### PR TITLE
CHANGE(netdata): Web-log: Change log format for rawx services

### DIFF
--- a/templates/web_log.conf.j2
+++ b/templates/web_log.conf.j2
@@ -10,7 +10,8 @@ autodetection_retry: {{ openio_netdata_python_d_retry }}
     name: '.openio.{{ openio_netdata_namespace }}.rawx.rawx-{{ loop.index0 }}.log.access'
     path: '/var/log/oio/sds/{{ openio_netdata_namespace }}/rawx-{{ loop.index0 }}/rawx-{{ loop.index0 }}-httpd-access.log'
     custom_log_format:
-        pattern: '\S+ \S+ \S+ \S+ \S+ \d+ \d+ \S+ \S+ (?P<address>\S+) \S+ (?P<method>\S+) (?P<code>\d+) (?P<resp_time>\d+) (?P<bytes_sent>\d+) (?P<resp_length>\d+) \S+ \S+ (?P<url>.*)'
+        pattern: '\S+ \S+ \S+ \S+  \S+ \S+ \S+ \S+ (?P<address>\S+) \S+ (?P<method>\S+) (?P<code>\d+) (?P<resp_time>\d+) (?P<bytes_sent>\d+) (?P<resp_length>\d+) \S+ \S+ (?P<url>.*)'
+
 {% endfor %}
 
 {% for service in ['meta1', 'meta2'] %}


### PR DESCRIPTION
 ##### SUMMARY

The rawx log format has been changed to use syslog. Following this
change, the date format has been modified to follow ISO-8601
specification. Example:

```sh
2019-11-29T11:01:33.521051+01:00 node1 OIO,OPENIO,rawx,1[81064]: info  81064 access INF - 192.   168.1.1:6201 192.168.1.10:62238 PUT 201 6137303 0 20009238 - tx194e5740990c46798f019-           005de0ec76 /4E07B6BD15AD68CDFFD2937F7A8218DDE6FE45D10BFA563FC64CD4301FF126C3
```

This change allows the collector to properly parse new rawx logs.

 ##### IMPACT

BREAKING CHANGE: do not deploy with httpd rawx

 ##### ADDITIONAL INFORMATION