### PR TITLE
CHANGE(netdata): Replace python.d redis collector with netdata plugin

### DIFF
--- a/filter_plugins/netdata.py
+++ b/filter_plugins/netdata.py
@@ -11,7 +11,8 @@ except ImportError:
 class FilterModule(object):
     def filters(self):
         return {
-            'aws_creds': self.aws_creds
+            'aws_creds': self.aws_creds,
+            'redis_roles': self.redis_roles
         }
 
     def aws_creds(self, data, type_='access'):
@@ -25,3 +26,27 @@ class FilterModule(object):
         if type_ == 'secret':
             return config.get('default', 'aws_secret_access_key')
         return config.get('default', 'aws_access_key_id')
+
+    def redis_roles(self, services):
+        """
+        Organise redis services into clusters for the redis collector
+        ---
+        Example:
+        services = [
+            {"ip": "10.10.10.11", "port": 6011, "role": "account"},
+            {"ip": "10.10.10.11", "port": 6411, "role": "ch"},
+            {"ip": "10.10.10.11", "port": 6511, "role": "bdb"}
+        ]
+        self.redis_roles(services)
+        > "10.10.10.11:6011:account,10.10.10.11:6411:ch,10.10.10.11:6511:bdb"
+        """
+        tmp = dict()
+        res = []
+        for service in services:
+            tmp.setdefault(service['role'], [])
+            tmp[service['role']].append(service)
+        for idx, cluster in enumerate(tmp.values()):
+            for service in cluster:
+                res.append("%s:%d:%s" %
+                           (service['ip'], service['port'], service['role']))
+        return ",".join(res)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,10 +42,10 @@
       tags: configure
 
     - name: Create temporary inventory directory
-      local_action:
-        module: tempfile
+      tempfile:
         state: directory
         suffix: inventory
+      delegate_to: localhost
       register: inv_dir
       changed_when: false
       become: false
@@ -99,8 +99,6 @@
           dest: "{{ openio_netdata_confdir }}/apps_groups.conf"
         - src: beanstalk.conf.j2
           dest: "{{ openio_netdata_confdir }}/python.d/beanstalk.conf"
-        - src: redis.conf.j2
-          dest: "{{ openio_netdata_confdir }}/python.d/redis.conf"
         - src: memcached.conf.j2
           dest: "{{ openio_netdata_confdir }}/python.d/memcached.conf"
       tags: configure

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -35,6 +35,7 @@
                  (inventory_hostname == openio_netdata_redis_hosts | first) else 'no' }}
   fs = {{ 'yes' if inventory_hostname in openio_netdata_oiofs_hosts else 'no' }}
   s3roundtrip = {{ 'yes' if inventory_hostname in openio_netdata_s3rt_hosts else 'no' }}
+  redis = {{ 'yes' if inventory.services.get('redis', []) else 'no' }}
 
 [plugin:openio]
   update every = {{ openio_netdata_global_update_every }}
@@ -46,6 +47,10 @@
   update every = {{ openio_netdata_global_update_every }}
   command options = --ns {{ openio_netdata_namespace }} --fast --addr {{ targets[0].ip }}:{{ targets[0].port }}
 {% endif %}
+
+[plugin:redis]
+  update every = {{ openio_netdata_global_update_every }}
+  command options = --targets {{ inventory.services.get('redis', []) | redis_roles }}
 
 [plugin:command]
   update every = {{ openio_netdata_global_update_every }}

--- a/templates/python.d.conf.j2
+++ b/templates/python.d.conf.j2
@@ -22,6 +22,6 @@ default_run: {{ openio_netdata_python_d_plugin_default_run }}
 # Setting any of these to "yes" will enable it.
 
 beanstalk: yes
-redis: yes
+redis: no
 web_log: {{ openio_netdata_python_d_plugin_web_log }}
 memcached: {{ openio_netdata_python_d_plugin_memcached }}

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -1,8 +1,0 @@
-#jinja2: lstrip_blocks: True
-# {{ ansible_managed }}
-autodetection_retry: {{ openio_netdata_python_d_retry }}
-{% for redis in inventory.services.get('redis', []) %}
-'{{ redis.ip }}:{{ redis.port}}':
-    host: '{{ redis.ip }}'
-    port:  {{ redis.port }}
-{% endfor %}


### PR DESCRIPTION
 ##### SUMMARY

The redis.plugin is available since openio-netdata-plugins 0.6.0, this
enables it in netdata.

 ##### IMPACT

The new redis collector exports metrics under different measurement
names; Grafana dashboads need to be provisioned for the 19.10 release

 ##### ADDITIONAL INFORMATION