### PR TITLE
CHANGE(netdata): Add security limits

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,4 +36,9 @@ openio_netdata_s3rt_bucket: "s3roundtrip-bucket"
 openio_netdata_s3rt_object: "s3roundtrip-object"
 openio_netdata_s3rt_aws_creds: "/root/.aws/credentials"
 openio_netdata_s3rt_timeout: 5
+
+
+openio_netdata_soft_limits: 10000 
+openio_netdata_hard_limits: 30000
+
 ...

--- a/files/commands/RedHat.conf
+++ b/files/commands/RedHat.conf
@@ -4,7 +4,7 @@ swift_version=rpm -q --qf "%{VERSION}\n" openio-sds-swift
 s3_version=rpm -q --qf "%{VERSION}\n" openio-sds-swift-plugin-swift3
 redis_version=redis-server --version | grep -oP ' v=\K.+? '
 zk_version=rpm -q --qf "%{VERSION}\n" zookeeper
-zk_lib_version=rpm -q --qf "%{VERSION}\n" zookeeper-lib
+zk_lib_version=rpm -q --qf "%{VERSION}\n" zookeeper-lib 
 beanstalkd_version=beanstalkd -v | awk 'BEGIN {err=1} NF == 2 {print $2; err = 0} END {exit err}'
 oiofs_version=rpm -q --qf "%{VERSION}\n" oiofs-fuse
 keystone_version=keystone-manage --version 2>&1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,6 +92,24 @@
       tags: configure
   when: inventory_hostname in openio_netdata_oio_hosts
 
+- name: Set open files limit non-systemd 
+  template:
+    src: "openio-security-limits.conf.j2"
+    dest: "/etc/security/limits.d/30-netdata.conf"
+    owner: "root"
+    group: "root"
+    mode: 0644
+  tags: configure
+
+- name: Set operating system limits on mmap  
+  template:
+    src: "openio-sysctl-netdata.conf.j2"
+    dest: "/etc/sysctl.d/netdata.conf"
+    owner: "root"
+    group: "root"
+    mode: 0644
+  tags: configure
+
 - name: Set global configuration
   vars:
     _inventory: "{{ inventory | d({}) }}"

--- a/templates/openio-security-limits.conf.j2
+++ b/templates/openio-security-limits.conf.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+
+netdata   soft    nofile  {{ openio_netdata_soft_limits }} 
+netdata   hard    nofile  {{ openio_netdata_hard_limits }}

--- a/templates/openio-sysctl-netdata.conf.j2
+++ b/templates/openio-sysctl-netdata.conf.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+vm.max_map_count=262144

--- a/templates/python.d.conf.j2
+++ b/templates/python.d.conf.j2
@@ -24,3 +24,4 @@ default_run: {{ openio_netdata_python_d_plugin_default_run }}
 beanstalk: yes
 redis: yes
 web_log: {{ openio_netdata_python_d_plugin_web_log }}
+


### PR DESCRIPTION
 ##### SUMMARY

- add new variables to set open files limit used by netdata
- increase The default operating system limits on mmap
- change check lib zookeeper on command.conf

 ##### IMPACT

 ##### ADDITIONAL INFORMATION