### PR TITLE
BUGFIX/MINOR(netdata): S3 Roundtrip: don't use the same bucket on each

### DIFF
--- a/templates/s3roundtrip.conf.j2
+++ b/templates/s3roundtrip.conf.j2
@@ -4,6 +4,6 @@ endpoint={{ openio_netdata_s3rt_endpoint}}
 access={{ s3creds['content'] | aws_creds('access') }}
 secret={{ s3creds['content'] | aws_creds('secret') }}
 region={{ openio_netdata_s3rt_region }}
-bucket={{ openio_netdata_s3rt_bucket }}
+bucket={{ openio_netdata_s3rt_bucket }}-{{ openio_netdata_s3rt_hosts.index(inventory_hostname) }}
 object={{ openio_netdata_s3rt_object }}
 timeout={{ openio_netdata_s3rt_timeout }}


### PR DESCRIPTION
host

 ##### SUMMARY

Performing operations on the same bucket when deploying on multiple
hosts will lead to 4xx errors (e.g. a roundtrip will try to upload into
a bucket deleted by another instance). This ensures that the buckets
used by each instance are not the same.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION