### PR TITLE
CHANGE(netdata): Command: new package for zookeeper-lib

### DIFF
--- a/files/commands/RedHat.conf
+++ b/files/commands/RedHat.conf
@@ -4,7 +4,7 @@ swift_version=rpm -q --qf "%{VERSION}\n" openio-sds-swift
 s3_version=rpm -q --qf "%{VERSION}\n" openio-sds-swift-plugin-swift3
 redis_version=redis-server --version | grep -oP ' v=\K.+? '
 zk_version=rpm -q --qf "%{VERSION}\n" zookeeper
-zk_lib_version=rpm -q --qf "%{VERSION}\n" zookeeper-lib
+zk_lib_version=rpm -q --qf "%{VERSION}\n" libzookeeper2
 beanstalkd_version=beanstalkd -v | awk 'BEGIN {err=1} NF == 2 {print $2; err = 0} END {exit err}'
 oiofs_version=rpm -q --qf "%{VERSION}\n" oiofs-fuse
 keystone_version=keystone-manage --version 2>&1


### PR DESCRIPTION
 ##### SUMMARY

The package zookeeper-lib has been renamed to libzookeeper2. This
updates the configuration of the command plugin to check for that
package name

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION